### PR TITLE
Make cmake respect CC and PATH compiler overrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,10 @@
 # Author: Peter Krusche <pkrusche@illumina.com>
 #
 cmake_minimum_required (VERSION 2.8)
+
+find_program(CMAKE_C_COMPILER NAMES $ENV{CC} gcc PATHS ENV PATH NO_DEFAULT_PATH)
+find_program(CMAKE_CXX_COMPILER NAMES $ENV{CXX} g++ PATHS ENV PATH NO_DEFAULT_PATH)
+
 project (HAPLOTYPES)
 
 set(CMAKE_EXPORT_COMPILE_COMMANDS 1)


### PR DESCRIPTION
Cmake does not respect non-system default compilers using the conventional
override methods (CC env variable and PATH). 
https://stackoverflow.com/questions/29902862/how-to-get-cmake-to-use-the-default-compiler-on-system-path