### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ RUN apt-get update && \
         zlib1g-dev && \
     apt-get clean -y
 
-RUN pip install bx-python
+RUN pip install bx-python==0.8.8
 
 # copy git repository into the image
 RUN mkdir -p /opt/hap.py-source


### PR DESCRIPTION
Use bx-python==0.8.8 to fix ImportError in som.py
By default python==0.8.9 is installed and causes the following error:

`ImportError: /usr/local/lib/python2.7/dist-packages/bx/intervals/intersection.so: undefined symbol: PyUnicodeUCS2_FromStringAndSize`